### PR TITLE
Fix PresenceSubscription Renewal

### DIFF
--- a/UCWASDK/UCWASDK/Models/PresenceSubscription.cs
+++ b/UCWASDK/UCWASDK/Models/PresenceSubscription.cs
@@ -60,6 +60,17 @@ namespace Microsoft.Skype.UCWA.Models
             return HttpService.Get<Memberships>(Links.memberships, cancellationToken);
         }
 
+        public async Task<PresenceSubscription> Renew(int duration = 30)
+        {
+           return await Renew(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task<PresenceSubscription> Renew(CancellationToken cancellationToken, int duration = 30)
+        {
+           var uri = Self + $"?duration={duration}";
+           return await HttpService.Post<PresenceSubscription>(uri, null, cancellationToken);
+        }
+
         public async Task Delete()
         {
             await Delete(HttpService.GetNewCancellationToken());

--- a/UCWASDK/UCWASDK/Models/PresenceSubscriptions.cs
+++ b/UCWASDK/UCWASDK/Models/PresenceSubscriptions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Skype.UCWA.Models
                 return null;
             
             JObject body = new JObject();
-            body["duration"] = 30;
+            body["duration"] = duration;
             body["uris"] = new JArray(uris);
             return await HttpService.Post<PresenceSubscription>(Self, body, cancellationToken);
         }


### PR DESCRIPTION
Currently only `PresenceSubscriptions` (with plural "s") offers a `Renew()` method.
During our testing using this method always failed.
With this PR a `Renew()` method was added to `PresenceSubscription` (without plural "s") which seems to work fine for us.

This also better fits the event model where in a `PresenceSubscriptionUpdated` event a `PresenceSubscription` (again without plural "s") is provided - allowing to directly renew it.

Additional fix: subscribing to presence no longer ignores given duration (was hard coded to `30` despite method parameter)